### PR TITLE
Fixed attachment id issue in edit item page

### DIFF
--- a/InfoPath/Samples/EmployeeRegistration.KnockOut.SinglePageApp/EmployeeRegistration.KnockOut.SinglePageApp/Assets/Emp-Registration-Form.js
+++ b/InfoPath/Samples/EmployeeRegistration.KnockOut.SinglePageApp/EmployeeRegistration.KnockOut.SinglePageApp/Assets/Emp-Registration-Form.js
@@ -505,6 +505,7 @@ function EmpViewModel() {
     
     // Load all attachments of current item
     self.loadAttachments = function (aID) {
+        self.AttachmentID(aID);
         var url = _spPageContextInfo.webAbsoluteUrl + "/_api/web/lists/getbytitle('EmpAttachments')/items/?$select=File/Name,Title&$expand=File&$filter=AttachmentID eq '" + aID + "'";
         $.ajax({
             url: url,


### PR DESCRIPTION
Fixed script logic to use existing attachment id in edit item page
